### PR TITLE
Improve string and bytes

### DIFF
--- a/conformance/conformance_test.rb
+++ b/conformance/conformance_test.rb
@@ -86,7 +86,7 @@ class ConformanceTest < Minitest::Test
     when :string_value
       Cel::String.new(value_proto.string_value)
     when :bytes_value
-      Cel::Bytes.new(value_proto.bytes_value.bytes)
+      Cel::Bytes.new(value_proto.bytes_value.b)
     when :object_value
       Cel::Types::Message.new(value_proto.object_value)
     when :list_value
@@ -116,7 +116,7 @@ class ConformanceTest < Minitest::Test
     when Cel::String
       Cel::Expr::Value.new(string_value: value.value)
     when Cel::Bytes
-      Cel::Expr::Value.new(bytes_value: value.value.pack("c*"))
+      Cel::Expr::Value.new(bytes_value: value.value.b)
     when Cel::Map
       entries = value.value.map do |k, v|
         { key: convert_to_conformance_value(k), value: convert_to_conformance_value(v) }

--- a/lib/cel/ast/elements.rb
+++ b/lib/cel/ast/elements.rb
@@ -255,8 +255,7 @@ module Cel
         else
           raise EvaluateError, "Could not convert #{@value} to bool"
         end
-      when TYPES[:bytes]
-        Bytes.new(@value.bytes)
+      when TYPES[:bytes] then Bytes.new(@value.b)
       when TYPES[:double]
         Number.new(:double, @value == "NaN" ? Float::NAN : @value.to_f)
       when TYPES[:int] then Number.new(:int, @value.to_i)
@@ -316,10 +315,6 @@ module Cel
       super(:bytes, value)
     end
 
-    def to_ary
-      [self]
-    end
-
     # Comparison method used to implement all other comparison methods. It is
     # called internally and expected to return a Ruby integer of -1, 0, or 1.
     def <=>(other)
@@ -331,7 +326,7 @@ module Cel
     def cast_to_type(type)
       case type
       when TYPES[:string]
-        str = @value.pack("C*").force_encoding("UTF-8")
+        str = @value.dup.force_encoding("UTF-8")
         raise EvaluateError, "Invalid UTF-8" unless str.valid_encoding?
 
         String.new(str)

--- a/lib/cel/parser.rb
+++ b/lib/cel/parser.rb
@@ -186,7 +186,8 @@ def double_literal(str)
 end
 
 def string_literal(parts)
-  Cel::AST::Literal.new(:string, convert_to_string(parts[:raw], parts[:str]))
+  string = convert_to_string(parts[:raw], parts[:str])
+  Cel::AST::Literal.new(:string, string.encode("UTF-8", invalid: :replace, undef: :replace))
 end
 
 def bytes_literal(parts)

--- a/lib/cel/parser.rb
+++ b/lib/cel/parser.rb
@@ -192,7 +192,7 @@ end
 
 def bytes_literal(parts)
   string = convert_to_string(parts[:raw], parts[:str])
-  Cel::AST::Literal.new(:bytes, string.unpack("C*"))
+  Cel::AST::Literal.new(:bytes, string.force_encoding("ASCII-8BIT"))
 end
 
 def global_call(function, *args)

--- a/lib/cel/parser.ry
+++ b/lib/cel/parser.ry
@@ -276,7 +276,8 @@ def double_literal(str)
 end
 
 def string_literal(parts)
-  Cel::AST::Literal.new(:string, convert_to_string(parts[:raw], parts[:str]))
+  string = convert_to_string(parts[:raw], parts[:str])
+  Cel::AST::Literal.new(:string, string.encode("UTF-8", invalid: :replace, undef: :replace))
 end
 
 def bytes_literal(parts)

--- a/lib/cel/parser.ry
+++ b/lib/cel/parser.ry
@@ -282,7 +282,7 @@ end
 
 def bytes_literal(parts)
   string = convert_to_string(parts[:raw], parts[:str])
-  Cel::AST::Literal.new(:bytes, string.unpack("C*"))
+  Cel::AST::Literal.new(:bytes, string.force_encoding("ASCII-8BIT"))
 end
 
 def global_call(function, *args)

--- a/lib/cel/protobuf.rb
+++ b/lib/cel/protobuf.rb
@@ -76,7 +76,7 @@ begin
         when :string
           Cel::String.new(value)
         when :bytes
-          Cel::Bytes.new(value.unpack("C*"))
+          Cel::Bytes.new(value.b)
         when Google::Protobuf::EnumDescriptor
           Cel::Number.new(:int, Cel::Protobuf.enum_lookup_name(type, value))
         when Google::Protobuf::Descriptor
@@ -242,20 +242,17 @@ begin
       BYTES_DESCRIPTOR = Google::Protobuf::BytesValue.descriptor
 
       def cast_to_proto(type)
-        # Google::Protobuf expects byte fields to be simple strings
-        str_value = @value.pack("C*")
-
         case type
         when :bytes
-          str_value
+          @value
         when BYTES_DESCRIPTOR
-          type.msgclass.new(value: str_value)
+          type.msgclass.new(value: @value)
         when Protobuf::ANY_DESCRIPTOR
-          message = Google::Protobuf::BytesValue.new(value: str_value)
+          message = Google::Protobuf::BytesValue.new(value: @value)
           Google::Protobuf::Any.pack(message)
         when Protobuf::VALUE_DESCRIPTOR
           # Canonical encoding of bytes for JSON is to base64 encode them
-          Google::Protobuf::Value.from_ruby(Base64.strict_encode64(str_value))
+          Google::Protobuf::Value.from_ruby(Base64.strict_encode64(@value))
         else
           raise EvaluateError, "Cannot convert #{self} to #{type.inspect}"
         end

--- a/lib/cel/types/message.rb
+++ b/lib/cel/types/message.rb
@@ -132,7 +132,7 @@ module Cel
         when Google::Protobuf::StringValue
           Cel::String.new(message.value)
         when Google::Protobuf::BytesValue
-          Cel::Bytes.new(message.value.unpack("C*"))
+          Cel::Bytes.new(message.value.b)
         when Google::Protobuf::Timestamp
           Cel::Timestamp.new(message.to_time)
         when Google::Protobuf::Duration

--- a/test/evaluate_test.rb
+++ b/test/evaluate_test.rb
@@ -82,7 +82,7 @@ class CelEvaluateTest < Minitest::Test
 
   def test_dynamic_proto
     assert_equal true, environment.evaluate("google.protobuf.BoolValue{value: true}").value
-    assert_equal "foo".bytes, environment.evaluate("google.protobuf.BytesValue{value: b'foo'}")
+    assert_equal "foo".b, environment.evaluate("google.protobuf.BytesValue{value: b'foo'}")
     assert_equal(-1500.0, environment.evaluate("google.protobuf.DoubleValue{value: -1.5e3}"))
     assert_equal(-1500.0, environment.evaluate("google.protobuf.FloatValue{value: -1.5e3}"))
     assert_equal(-123, environment.evaluate("google.protobuf.Int32Value{value: -123}"))
@@ -181,7 +181,7 @@ class CelEvaluateTest < Minitest::Test
     assert_equal 1, environment.evaluate("uint(1)")
     assert_equal 1.0, environment.evaluate("double(1)")
     assert_equal "1", environment.evaluate("string(1)")
-    assert_equal [97], environment.evaluate("bytes('a')")
+    assert_equal "a".b, environment.evaluate("bytes('a')")
   end
 
   def test_func_matches

--- a/test/parse_test.rb
+++ b/test/parse_test.rb
@@ -22,7 +22,7 @@ module AstShorthand
   end
 
   def self.b(bytes)
-    Cel::AST::Literal.new(:bytes, bytes)
+    Cel::AST::Literal.new(:bytes, bytes.pack("C*"))
   end
 
   def self.struct(name, fields_hash = {})


### PR DESCRIPTION
- Apparently for conformance, if you create an invalid string literal, it should be automatically converted to safe UTF-8. However, this should only be the case for literals - casting a byte string to a string should throw an exception if it's not valid.
- Protobuf on Ruby uses normal ruby strings for bytes, and there's really no benefit to having the byte value object be an array of integers rather than just a binary string. Therefore, switching their internal structure simplifies the code a bit.