### PR TITLE
Rename Runner->Program & Program->Interpreter

### DIFF
--- a/conformance/conformance_test.rb
+++ b/conformance/conformance_test.rb
@@ -42,7 +42,7 @@ class ConformanceTest < Minitest::Test
           env = Cel::Environment.new(declarations, container)
 
           # Parse
-          ast = Cel::Parser.new.parse(test.expr)
+          ast = env.parse(test.expr)
 
           # Check
           env.check(ast) unless test.disable_check

--- a/lib/cel/environment.rb
+++ b/lib/cel/environment.rb
@@ -44,29 +44,18 @@ module Cel
       check(ast)
     end
 
-    # Creates a runner for the given AST
+    # Creates a program for the given AST. The returned program is stateless and
+    # cacheable.
     def program(ast)
       ast = @parser.parse(ast) if ast.is_a?(::String)
-      Runner.new(self, ast)
+      Program.plan(self, ast)
     end
 
     # Parses, checks, and evaluates the given expression with the given bindings
     def evaluate(expr, bindings = nil)
       expr = @parser.parse(expr) if expr.is_a?(::String)
       check(expr)
-      Runner.new(self, expr).evaluate(bindings)
-    end
-  end
-
-  class Runner
-    def initialize(environment, ast)
-      @environment = environment
-      @ast = ast
-    end
-
-    def evaluate(bindings = nil)
-      context = Context.new(@environment.declarations, bindings, @environment.function_registry)
-      Program.new(context, @environment.container).evaluate(@ast)
+      Program.plan(self, expr).evaluate(bindings)
     end
   end
 end

--- a/lib/cel/program.rb
+++ b/lib/cel/program.rb
@@ -1,117 +1,22 @@
 # frozen_string_literal: true
 
+require "cel/program/interpreter"
 require "cel/program/comprehension"
 
 module Cel
   class Program
-    def initialize(context, container)
-      @context = context
-      @container = container
+    def self.plan(environment, ast)
+      new(environment, ast)
     end
 
-    def evaluate(ast)
-      case ast
-      when AST::Literal then evaluate_literal(ast)
-      when AST::Identifier then evaluate_identifier(ast)
-      when AST::Select then evaluate_select(ast)
-      when AST::Call then evaluate_call(ast)
-      when AST::CreateList then evaluate_create_list(ast)
-      when AST::CreateStruct then evaluate_create_struct(ast)
-      when AST::Comprehension then evaluate_comprehension(ast)
-      else
-        raise "Unexpected AST node"
-      end
+    def initialize(environment, ast)
+      @environment = environment
+      @ast = ast
     end
 
-    alias_method :call, :evaluate
-
-    private
-
-    def evaluate_literal(ast)
-      case ast.type
-      when :int, :uint, :double
-        Cel::Number.new(ast.type, ast.value)
-      when :bool
-        Cel::Bool.new(ast.value)
-      when :string
-        Cel::String.new(ast.value)
-      when :bytes
-        Cel::Bytes.new(ast.value)
-      when :null
-        Cel::Null.new
-      else
-        raise "Unexpected literal type: #{ast.inspect}"
-      end
-    end
-
-    def evaluate_identifier(ast)
-      name_sym = ast.name.to_sym
-      if Cel::PRIMITIVE_TYPES.include?(name_sym)
-        Cel::TYPES.fetch(name_sym)
-      else
-        @context.lookup(ast.name)
-      end
-    end
-
-    def evaluate_select(ast)
-      operand = evaluate(ast.operand)
-      if ast.test_only
-        raise EvaluateError, "select is not supported on: #{operand}" unless operand.respond_to?(:field_set?)
-
-        operand.field_set?(ast.field)
-
-      else
-        case operand
-        when Cel::Map
-          operand[Cel::String.new(ast.field)]
-        when Cel::Message
-          operand[ast.field]
-        when Protobuf::EnumLookup
-          operand.select(ast.field)
-        else
-          raise EvaluateError, "select is not supported on: #{operand}"
-        end
-      end
-    end
-
-    def evaluate_call(ast)
-      args = ast.args.map { |arg| evaluate(arg) }
-      args.unshift(evaluate(ast.target)) if ast.target
-
-      if (binding = @context.lookup_function(ast, args))
-        binding.call(*args)
-      else
-        raise EvaluateError, "unhandled call: #{ast.inspect}"
-      end
-    end
-
-    def evaluate_create_list(ast)
-      Cel::List.new(ast.elements.map { |e| evaluate(e) })
-    end
-
-    def evaluate_create_struct(ast)
-      if ast.message_name == ""
-        hash = ast.entries.to_h { |entry| [evaluate(entry.key), evaluate(entry.value)] }
-        Cel::Map.new(hash)
-      elsif !defined?(Cel::Message)
-        warn "DEPRECATED: Use of named structs without protobufs is deprecated"
-        hash = ast.entries.to_h { |entry| [Cel::String.new(entry.key), evaluate(entry.value)] }
-        Cel::Map.new(hash)
-      else
-        # Look up descriptor in the protobuf pool
-        pool = Google::Protobuf::DescriptorPool.generated_pool
-        qualified_names = @container.resolve(ast.message_name)
-        qualified_name = qualified_names.find { |name| pool.lookup(name) }
-        raise EvaluateError, "unknown type: #{ast.message_name}" unless qualified_name
-
-        # Build the protobuf message
-        hash = ast.entries.to_h { |entry| [entry.key, evaluate(entry.value)] }
-        Cel::Message.from_cel_fields(pool.lookup(qualified_name), hash)
-      end
-    end
-
-    def evaluate_comprehension(ast)
-      Comprehension.new(@context, @container, ast).call
+    def evaluate(bindings = nil)
+      context = Context.new(@environment.declarations, bindings, @environment.function_registry)
+      Interpreter.new(context, @environment.container).evaluate(@ast)
     end
   end
 end

--- a/lib/cel/program/comprehension.rb
+++ b/lib/cel/program/comprehension.rb
@@ -2,7 +2,7 @@
 
 module Cel
   class Program
-    class Comprehension < Program
+    class Comprehension < Interpreter
       def initialize(context, container, comprehension)
         super(context, container)
         @comprehension = comprehension

--- a/lib/cel/program/interpreter.rb
+++ b/lib/cel/program/interpreter.rb
@@ -1,0 +1,117 @@
+# frozen_string_literal: true
+
+module Cel
+  class Program
+    class Interpreter
+      def initialize(context, container)
+        @context = context
+        @container = container
+      end
+
+      def evaluate(ast)
+        case ast
+        when AST::Literal then evaluate_literal(ast)
+        when AST::Identifier then evaluate_identifier(ast)
+        when AST::Select then evaluate_select(ast)
+        when AST::Call then evaluate_call(ast)
+        when AST::CreateList then evaluate_create_list(ast)
+        when AST::CreateStruct then evaluate_create_struct(ast)
+        when AST::Comprehension then evaluate_comprehension(ast)
+        else
+          raise "Unexpected AST node"
+        end
+      end
+
+      alias_method :call, :evaluate
+
+      private
+
+      def evaluate_literal(ast)
+        case ast.type
+        when :int, :uint, :double
+          Cel::Number.new(ast.type, ast.value)
+        when :bool
+          Cel::Bool.new(ast.value)
+        when :string
+          Cel::String.new(ast.value)
+        when :bytes
+          Cel::Bytes.new(ast.value)
+        when :null
+          Cel::Null.new
+        else
+          raise "Unexpected literal type: #{ast.inspect}"
+        end
+      end
+
+      def evaluate_identifier(ast)
+        name_sym = ast.name.to_sym
+        if Cel::PRIMITIVE_TYPES.include?(name_sym)
+          Cel::TYPES.fetch(name_sym)
+        else
+          @context.lookup(ast.name)
+        end
+      end
+
+      def evaluate_select(ast)
+        operand = evaluate(ast.operand)
+        if ast.test_only
+          raise EvaluateError, "select is not supported on: #{operand}" unless operand.respond_to?(:field_set?)
+
+          operand.field_set?(ast.field)
+
+        else
+          case operand
+          when Cel::Map
+            operand[Cel::String.new(ast.field)]
+          when Cel::Message
+            operand[ast.field]
+          when Protobuf::EnumLookup
+            operand.select(ast.field)
+          else
+            raise EvaluateError, "select is not supported on: #{operand}"
+          end
+        end
+      end
+
+      def evaluate_call(ast)
+        args = ast.args.map { |arg| evaluate(arg) }
+        args.unshift(evaluate(ast.target)) if ast.target
+
+        if (binding = @context.lookup_function(ast, args))
+          binding.call(*args)
+        else
+          raise EvaluateError, "unhandled call: #{ast.inspect}"
+        end
+      end
+
+      def evaluate_create_list(ast)
+        Cel::List.new(ast.elements.map { |e| evaluate(e) })
+      end
+
+      def evaluate_create_struct(ast)
+        if ast.message_name == ""
+          hash = ast.entries.to_h { |entry| [evaluate(entry.key), evaluate(entry.value)] }
+          Cel::Map.new(hash)
+        elsif !defined?(Cel::Message)
+          warn "DEPRECATED: Use of named structs without protobufs is deprecated"
+          hash = ast.entries.to_h { |entry| [Cel::String.new(entry.key), evaluate(entry.value)] }
+          Cel::Map.new(hash)
+        else
+          # Look up descriptor in the protobuf pool
+          pool = Google::Protobuf::DescriptorPool.generated_pool
+          qualified_names = @container.resolve(ast.message_name)
+          qualified_name = qualified_names.find { |name| pool.lookup(name) }
+          raise EvaluateError, "unknown type: #{ast.message_name}" unless qualified_name
+
+          # Build the protobuf message
+          hash = ast.entries.to_h { |entry| [entry.key, evaluate(entry.value)] }
+          Cel::Message.from_cel_fields(pool.lookup(qualified_name), hash)
+        end
+      end
+
+      def evaluate_comprehension(ast)
+        Comprehension.new(@context, @container, ast).call
+      end
+    end
+  end
+end


### PR DESCRIPTION
This is just setup for pulling in the planning phase to pre-process the AST. I think program sounds better than runner for this container class that stores the extra data needed to evaluate the AST quickly.