### PR TITLE
Mostly implement conformant string extensions

### DIFF
--- a/lib/cel/extra/formatting.rb
+++ b/lib/cel/extra/formatting.rb
@@ -1,0 +1,121 @@
+# frozen_string_literal: true
+
+require "strscan"
+
+module Cel
+  module Extra
+    class Formatting
+      def self.convert_to_string(value)
+        return "null" if value.is_a?(Cel::Null)
+
+        value.cast_to_type(TYPES[:string]).value
+      end
+
+      def self.convert_to_integer(format_str, value)
+        return format(format_str, value.value) if value.is_a?(Cel::Number) && value.type != :double
+
+        raise EvaluateError, "Cannot convert #{value} to integer"
+      end
+
+      def self.convert_to_float(format_str, value)
+        if value.is_a?(Cel::String)
+          case value.value
+          when "NaN" then return "NaN"
+          when "Infinity" then return "∞"
+          when "-Infinity" then return "-∞"
+          end
+        elsif value.is_a?(Cel::Number) && value.type == :double
+          return format(format_str, value.value)
+        end
+
+        raise EvaluateError, "Cannot convert #{value} to float"
+      end
+
+      def self.convert_to_hex(format_str, value)
+        lower_case = format_str[1] == "x"
+        if value.is_a?(Cel::String) || value.is_a?(Cel::Bytes)
+          hex = value.value.unpack1("H*")
+          lower_case ? hex : hex.upcase
+        elsif value.is_a?(Cel::Number) && value.type != :double
+          format(format_str, value.value)
+        else
+          raise EvaluateError, "Cannot convert #{value} to hexadecimal"
+        end
+      end
+
+      def self.convert_to_binary(value)
+        if value.is_a?(Cel::Number) && value.type != :double
+          format("%b", value.value)
+        elsif value.is_a?(Cel::Bool)
+          value.value ? "1" : "0"
+        else
+          raise EvaluateError, "Cannot convert #{value} to binary"
+        end
+      end
+
+      CLAUSES = {
+        string: method(:convert_to_string),
+        decimal: method(:convert_to_integer),
+        float: method(:convert_to_float),
+        exponential: method(:convert_to_float),
+        binary: method(:convert_to_binary),
+        hex: method(:convert_to_hex),
+        octal: method(:convert_to_integer),
+      }.freeze
+
+      def initialize(format_string)
+        @format_string = format_string
+        @clauses = []
+        @parsed_format_string = nil
+      end
+
+      def call(args_list)
+        parse!
+
+        args = args_list.value
+        raise Cel::Error, "Arg count mismatch: #{@clauses.size} vs #{args.size}" unless @clauses.size == args.size
+
+        format_args = args.zip(@clauses).map do |arg, (f, method)|
+          method.arity == 1 ? method.call(arg) : method.call(f, arg)
+        end
+        format(@parsed_format_string, *format_args)
+      end
+
+      private
+
+      def parse!
+        return if @parsed_format_string
+
+        scanner = StringScanner.new(@format_string)
+        @parsed_format_string = ::String.new(capacity: @format_string.size)
+        until scanner.eos?
+          if scanner.scan(/[^%]+/) || scanner.scan("%%")
+            @parsed_format_string << scanner.matched
+            next
+          end
+
+          method =
+            if scanner.scan("%s")
+              CLAUSES.fetch(:string)
+            elsif scanner.scan("%d")
+              CLAUSES.fetch(:decimal)
+            elsif scanner.scan(/%(\.\d+)?f/)
+              CLAUSES.fetch(:float)
+            elsif scanner.scan(/%(\.\d+)?e/)
+              CLAUSES.fetch(:exponential)
+            elsif scanner.scan("%b")
+              CLAUSES.fetch(:binary)
+            elsif scanner.scan(/%[xX]/)
+              CLAUSES.fetch(:hex)
+            elsif scanner.scan("%o")
+              CLAUSES.fetch(:octal)
+            else
+              raise Cel::Error, "Could not parse format string at #{scanner.pos}: #{@format_string.inspect}"
+            end
+          @clauses << [scanner.matched, method]
+          @parsed_format_string << "%s"
+        end
+      end
+    end
+  end
+end

--- a/lib/cel/extra/formatting.rb
+++ b/lib/cel/extra/formatting.rb
@@ -78,7 +78,7 @@ module Cel
         format_args = args.zip(@clauses).map do |arg, (f, method)|
           method.arity == 1 ? method.call(arg) : method.call(f, arg)
         end
-        format(@parsed_format_string, *format_args)
+        format(@parsed_format_string, *format_args).force_encoding("UTF-8")
       end
 
       private

--- a/lib/cel/extra/strings.rb
+++ b/lib/cel/extra/strings.rb
@@ -1,0 +1,160 @@
+# frozen_string_literal: true
+
+require "base64"
+require "cel/extra/formatting"
+
+module Cel
+  module Extra
+    module Strings
+      class << self
+        extend FunctionBindings
+
+        cel_func { receiver_function("charAt", :string, %i[int], :string) }
+        def char_at(string, index)
+          str = string.value
+          i = index.value
+          raise EvaluateError, "Index out of bounds: #{i}" if i.negative? || i > str.length
+
+          String.new(i == str.length ? "" : str[i])
+        end
+
+        cel_func do
+          receiver_function("indexOf", :string, %i[string], :int)
+          receiver_function("indexOf", :string, %i[string int], :int)
+        end
+        def index_of(string, match, start = nil)
+          i = start&.value || 0
+          raise EvaluateError, "Start out of bounds: #{i}" if i.negative?
+
+          Number.new(:int, string.value.index(match.value, i) || -1)
+        end
+
+        cel_func do
+          receiver_function("lastIndexOf", :string, %i[string], :int)
+          receiver_function("lastIndexOf", :string, %i[string int], :int)
+        end
+        def last_index_of(string, match, start = nil)
+          str = string.value
+          i = start&.value || str.length
+          raise EvaluateError, "Start out of bounds: #{i}" if i.negative?
+
+          Number.new(:int, str.rindex(match.value, i) || -1)
+        end
+
+        cel_func { receiver_function("lowerAscii", :string, [], :string) }
+        def lower_ascii(string)
+          String.new(string.value.downcase(:ascii))
+        end
+
+        cel_func do
+          receiver_function("replace", :string, %i[string string], :string)
+          receiver_function("replace", :string, %i[string string int], :string)
+        end
+        def replace(string, match, replace, count = nil)
+          count_value = count&.value
+          if count_value.nil? || count_value.negative?
+            String.new(string.value.gsub(match.value, replace.value))
+          elsif count_value.zero?
+            string
+          else
+            replace_value = replace.value
+            result = string.value.gsub(match.value) do |m|
+              next m if count_value.zero?
+
+              count_value -= 1
+              replace_value
+            end
+            String.new(result)
+          end
+        end
+
+        cel_func do
+          receiver_function("split", :string, %i[string], ListType[:string])
+          receiver_function("split", :string, %i[string int], ListType[:string])
+        end
+        def split(string, match, count = nil)
+          count_value = count&.value || -1
+          return List.new([]) if count_value.zero?
+
+          items =
+            if count_value.negative?
+              string.value.split(match.value, -1) # No limit
+            else
+              string.value.split(match.value, count_value)
+            end
+          items.map! { |s| String.new(s) }
+
+          List.new(items)
+        end
+
+        cel_func do
+          receiver_function("substring", :string, %i[int], :string)
+          receiver_function("substring", :string, %i[int int], :string)
+        end
+        def substring(string, start, end_index = nil)
+          str = string.value
+          i = start.value
+          len = str.length
+          raise EvaluateError, "Start out of bounds: #{i}" if i.negative? || i > len
+
+          return String.new(str[i..]) if end_index.nil?
+
+          end_value = end_index.value
+          raise EvaluateError, "Invalid range: start #{i} end #{end_value}" if i > end_value
+          raise EvaluateError, "End out of bounds: #{end_value}" if end_value.negative? || end_value > len
+
+          String.new(str[i...end_value])
+        end
+
+        TRIM_REGEXP = /^[[:space:]]*(.*?)[[:space:]]*$/
+        cel_func { receiver_function("trim", :string, [], :string) }
+        def trim(string)
+          output = string.value.sub(TRIM_REGEXP, '\1')
+          String.new(output)
+        end
+
+        cel_func { receiver_function("upperAscii", :string, [], :string) }
+        def upper_ascii(string)
+          String.new(string.value.upcase(:ascii))
+        end
+
+        #
+        # Version 1
+        #
+
+        cel_func { receiver_function("format", :string, [ListType[:any]], :string) }
+        def format_string(string, args)
+          String.new(Formatting.new(string.value).call(args))
+        end
+
+        cel_func { global_function("strings.quote", [:string], :string) }
+        def quote(string)
+          String.new(string.value.inspect)
+        end
+
+        #
+        # Version 2
+        #
+
+        cel_func do
+          receiver_function("join", ListType[:string], [], :string)
+          receiver_function("join", ListType[:string], [:string], :string)
+        end
+        def join(list, delimiter = nil)
+          delimiter_str = delimiter ? delimiter.value : ""
+          list_strs = list.value.map(&:value)
+          String.new(list_strs.join(delimiter_str))
+        end
+
+        #
+        # Version 3
+        #
+
+        cel_func { receiver_function("reverse", :string, [], :string) }
+        def reverse(string)
+          String.new(string.value.reverse)
+        end
+      end
+    end
+  end
+end

--- a/lib/cel/values/string.rb
+++ b/lib/cel/values/string.rb
@@ -37,6 +37,7 @@ module Cel
 
     def cast_to_type(type)
       case type
+      when TYPES[:string] then self
       when TYPES[:bool]
         if TRUE_VALUE.include?(@value)
           Bool.new(true)

--- a/test/evaluate_test.rb
+++ b/test/evaluate_test.rb
@@ -307,18 +307,6 @@ class CelEvaluateTest < Minitest::Test
 
   private
 
-  def assert_value(ruby_or_cel_value, cel_value)
-    if ruby_or_cel_value.is_a?(Cel::Value)
-      assert_equal(ruby_or_cel_value, cel_value)
-    else
-      assert_equal(ruby_or_cel_value, cel_value.to_ruby)
-    end
-  end
-
-  def assert_nil_value(cel_value)
-    assert_nil cel_value.to_ruby
-  end
-
   def environment(*args)
     Cel::Environment.new(*args)
   end

--- a/test/extra/formatting_test.rb
+++ b/test/extra/formatting_test.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+require_relative "../test_helper"
+require "cel/extra/formatting"
+
+class CelExtraFormattingTest < Minitest::Test
+  def test_basic_formatting
+    assert_equal "no substitution", cel_format("no substitution")
+    assert_equal "str is filler and some more", cel_format("str is %s and some more", "filler")
+    assert_equal "% and also %", cel_format("%% and also %%")
+    assert_equal "%text%", cel_format("%%%s%%", "text")
+    assert_equal "percent on the right%", cel_format("percent on the right%%")
+    assert_equal "%percent on the left", cel_format("%%percent on the left")
+  end
+
+  def test_string_format
+    assert_equal "null: null", cel_format("null: %s", nil)
+    assert_equal "999999999999", cel_format("%s", 999_999_999_999)
+    assert_equal "some bytes: xyz", cel_format("some bytes: %s", Cel::Bytes.new("xyz"))
+  end
+
+  def test_decimal_format
+    assert_equal "42", cel_format("%d", 42)
+    assert_equal "uint(64)", cel_format("uint(%d)", Cel::Number.new(:uint, 64))
+    assert_raises(Cel::EvaluateError) { cel_format("%d", 3.2) }
+    assert_raises(Cel::EvaluateError) { cel_format("%d", nil) }
+  end
+
+  def test_float_format
+    assert_equal "2.718280", cel_format("%f", 2.71828) # Check default precision
+    assert_equal "1.234", cel_format("%.3f", 1.2345)
+    assert_equal "NaN", cel_format("%f", "NaN")
+    assert_equal "∞", cel_format("%f", "Infinity")
+    assert_equal "-∞", cel_format("%f", "-Infinity")
+    assert_raises(Cel::EvaluateError) { cel_format("%f", 42) }
+    assert_raises(Cel::EvaluateError) { cel_format("%f", nil) }
+  end
+
+  def test_binary_format
+    assert_equal "this is 5 in binary: 101", cel_format("this is 5 in binary: %b", 5)
+    assert_equal "unsigned 64 in binary: 1000000", cel_format("unsigned 64 in binary: %b", 64)
+    assert_equal "bit set from bool: 1", cel_format("bit set from bool: %b", true)
+    assert_raises(Cel::EvaluateError) { cel_format("%b", nil) }
+  end
+
+  def test_hex_format
+    assert_equal "1e is 20 in hexadecimal", cel_format("%x is 20 in hexadecimal", 30)
+    assert_equal "1E is 20 in hexadecimal", cel_format("%X is 20 in hexadecimal", 30)
+    assert_equal "1770 is 6000 in hexadecimal", cel_format("%X is 6000 in hexadecimal", Cel::Number.new(:uint, 6000))
+    assert_equal "48656c6c6f20776f726c6421", cel_format("%x", "Hello world!")
+    assert_equal "48656C6C6F20776F726C6421", cel_format("%X", "Hello world!")
+    assert_equal "6279746520737472696e67", cel_format("%x", Cel::Bytes.new("byte string"))
+    assert_equal "6279746520737472696E67", cel_format("%X", Cel::Bytes.new("byte string"))
+    assert_raises(Cel::EvaluateError) { cel_format("%x", 2.5) }
+    assert_raises(Cel::EvaluateError) { cel_format("%X", nil) }
+  end
+
+  def test_octal_format
+    assert_equal "13", cel_format("%o", 11)
+    assert_equal(
+      "this is an unsigned octal: 177777",
+      cel_format("this is an unsigned octal: %o", Cel::Number.new(:uint, 65_535))
+    )
+    assert_raises(Cel::EvaluateError) { cel_format("%o", 3.14) }
+    assert_raises(Cel::EvaluateError) { cel_format("%o", nil) }
+  end
+
+  def test_checker
+    assert_raises(Cel::Error) { cel_format("%d %d %d", [1, 2]) }
+  end
+
+  private
+
+  def cel_format(string, *args)
+    Cel::Extra::Formatting.new(string).call(Cel.to_value(args))
+  end
+end

--- a/test/extra/strings_test.rb
+++ b/test/extra/strings_test.rb
@@ -1,0 +1,142 @@
+# frozen_string_literal: true
+
+require_relative "../test_helper"
+require "cel/extra/strings"
+
+class CelExtraStringsTest < Minitest::Test
+  def test_char_at
+    assert_value "o", evaluate("'tacocat'.charAt(3)")
+    assert_value "", evaluate("'tacocat'.charAt(7)")
+    assert_value "©", evaluate("'©αT'.charAt(0)")
+    assert_value "α", evaluate("'©αT'.charAt(1)")
+    assert_value "T", evaluate("'©αT'.charAt(2)")
+    assert_raises(Cel::EvaluateError) { evaluate("'a'.charAt(-1)") }
+    assert_raises(Cel::EvaluateError) { evaluate("'a'.charAt(2)") }
+  end
+
+  def test_index_of
+    assert_value 0, evaluate("'tacocat'.indexOf('')")
+    assert_value 1, evaluate("'tacocat'.indexOf('ac')")
+    assert_value(-1, evaluate("'tacocat'.indexOf('none')"))
+    assert_value 3, evaluate("'tacocat'.indexOf('', 3)")
+    assert_value 5, evaluate("'tacocat'.indexOf('a', 3)")
+    assert_value 5, evaluate("'tacocat'.indexOf('at', 3)")
+    assert_value 2, evaluate("'ta©o©αT'.indexOf('©')")
+    assert_value 4, evaluate("'ta©o©αT'.indexOf('©', 3)")
+    assert_value 4, evaluate("'ta©o©αT'.indexOf('©αT', 3)")
+    assert_value(-1, evaluate("'ta©o©αT'.indexOf('©α', 5)"))
+    assert_value 2, evaluate("'ijk'.indexOf('k')")
+    assert_value 0, evaluate("'hello wello'.indexOf('hello wello')")
+    assert_value 7, evaluate("'hello wello'.indexOf('ello', 6)")
+  end
+
+  def test_last_index_of
+    assert_value 7, evaluate("'tacocat'.lastIndexOf('')")
+    assert_value 5, evaluate("'tacocat'.lastIndexOf('at')")
+    assert_value(-1, evaluate("'tacocat'.lastIndexOf('none')"))
+    assert_value 3, evaluate("'tacocat'.lastIndexOf('', 3)")
+    assert_value 1, evaluate("'tacocat'.lastIndexOf('a', 3)")
+    assert_value 4, evaluate("'ta©o©αT'.lastIndexOf('©')")
+    assert_value 2, evaluate("'ta©o©αT'.lastIndexOf('©', 3)")
+    assert_value 4, evaluate("'ta©o©αT'.lastIndexOf('©α', 4)")
+    assert_value 1, evaluate("'hello wello'.lastIndexOf('ello', 6)")
+    assert_value 0, evaluate("'hello wello'.lastIndexOf('hello wello')")
+  end
+
+  def test_lower_ascii
+    assert_value "tacocat", evaluate("'TacoCat'.lowerAscii()")
+    assert_value "tacocÆt", evaluate("'TacoCÆt'.lowerAscii()")
+    assert_value "tacocÆt xii", evaluate("'TacoCÆt Xii'.lowerAscii()")
+  end
+
+  def test_replace
+    assert_value "12 days 12 hours", evaluate("'12 days 12 hours'.replace('{0}', '2')")
+    assert_value "2 days 2 hours", evaluate("'{0} days {0} hours'.replace('{0}', '2')")
+    assert_value "2 days 23 hours", evaluate("'{0} days {0} hours'.replace('{0}', '2', 1).replace('{0}', '23')")
+    assert_value "1 ©o©α taco", evaluate("'1 ©αT taco'.replace('αT', 'o©α')")
+    assert_value "_h_e_l_l_o_ _h_e_l_l_o_", evaluate("'hello hello'.replace('', '_')")
+    assert_value "ello ello", evaluate("'hello hello'.replace('h', '')")
+  end
+
+  def test_split
+    assert_value %w[hello world], evaluate("'hello world'.split(' ')")
+    assert_value [], evaluate("'hello world events!'.split(' ', 0)")
+    assert_value ["hello world events!"], evaluate("'hello world events!'.split(' ', 1)")
+    assert_value %w[o o o o], evaluate("'o©o©o©o'.split('©', -1)")
+    assert_value ["1", "2", "", "3", "4", "", ""], evaluate("'1,2,,3,4,,'.split(',', -4)")
+  end
+
+  def test_substring
+    assert_value "cat", evaluate("'tacocat'.substring(4)")
+    assert_value "", evaluate("'tacocat'.substring(7)")
+    assert_value "taco", evaluate("'tacocat'.substring(0, 4)")
+    assert_value "", evaluate("'tacocat'.substring(4, 4)")
+    assert_value "©o©α", evaluate("'ta©o©αT'.substring(2, 6)")
+    assert_value "", evaluate("'ta©o©αT'.substring(7, 7)")
+    assert_raises(Cel::EvaluateError) { evaluate("'tacocat'.substring(40)") }
+    assert_raises(Cel::EvaluateError) { evaluate("'tacocat'.substring(-1)") }
+    assert_raises(Cel::EvaluateError) { evaluate("'tacocat'.substring(1, 50)") }
+    assert_raises(Cel::EvaluateError) { evaluate("'tacocat'.substring(49, 50)") }
+    assert_raises(Cel::EvaluateError) { evaluate("'tacocat'.substring(4, 3)") }
+  end
+
+  def test_trim
+    assert_value "text", evaluate(%q(' \f\n\r\t\vtext  '.trim()))
+    assert_value "text", evaluate(%q('\u0085\u00a0\u1680text'.trim()))
+    assert_value "text", evaluate(%q('text\u2000\u2001\u2002\u2003\u2004\u2004\u2006\u2007\u2008\u2009'.trim()))
+    assert_value "text", evaluate(%q('\u200atext\u2028\u2029\u202F\u205F\u3000'.trim()))
+    assert_value "\u180etext\u200b\u200c\u200d\u2060\ufeff",
+                 evaluate(%q('\u180etext\u200b\u200c\u200d\u2060\ufeff'.trim()))
+  end
+
+  def test_upper_ascii
+    assert_value "TACOCAT", evaluate("'tacoCat'.upperAscii()")
+    assert_value "TACOCαT", evaluate("'tacoCαt'.upperAscii()")
+  end
+
+  def test_strings_quote
+    assert_value '"first\nsecond"', evaluate(%q(strings.quote('first\nsecond')))
+    assert_value '"bell\a"', evaluate(%q(strings.quote('bell\a')))
+    assert_value '"backspace\b"', evaluate(%q(strings.quote('backspace\b')))
+    assert_value '"formfeed\f"', evaluate(%q(strings.quote('formfeed\f')))
+    assert_value '"carriage \r return"', evaluate(%q(strings.quote('carriage \r return')))
+    assert_value '"horizontal tab\t"', evaluate(%q(strings.quote('horizontal tab\t')))
+    assert_value '"vertical \v tab"', evaluate(%q(strings.quote('vertical \v tab')))
+    assert_value '"double \\\\\\\\ slash"', evaluate('strings.quote("double \\\\\\\\ slash")')
+    assert_value '"two escape sequences \a\n"', evaluate('strings.quote("two escape sequences \a\n")')
+    assert_value '"verbatim"', evaluate('strings.quote("verbatim")')
+    assert_value '"ends with \\\\"', evaluate('strings.quote("ends with \\\\")')
+    assert_value '"\\\\ starts with"', evaluate('strings.quote("\\\\ starts with")')
+    assert_value '"printable unicode😀"', evaluate('strings.quote("printable unicode😀")')
+    assert_value '"mid string \\" quote"', evaluate('strings.quote("mid string \" quote")')
+    assert_value '"single-quote with \"double quote\""', evaluate(%q(strings.quote('single-quote with "double quote"')))
+    assert_value %q("size('ÿ')"), evaluate(%q(strings.quote("size('ÿ')")))
+    assert_value %q("size('πέντε')"), evaluate(%q(strings.quote("size('πέντε')")))
+    assert_value '"завтра"', evaluate('strings.quote("завтра")')
+    assert_value '""', evaluate('strings.quote("")')
+  end
+
+  def test_join
+    assert_value "xy", evaluate("['x', 'y'].join()")
+    assert_value "x-y", evaluate("['x', 'y'].join('-')")
+    assert_value "", evaluate("[].join()")
+    assert_value "", evaluate("[].join('-')")
+  end
+
+  def test_reverse
+    assert_value "smug", evaluate("'gums'.reverse()")
+    assert_value "semordnilap", evaluate("'palindromes'.reverse()")
+    assert_value "htimS nhoJ", evaluate("'John Smith'.reverse()")
+    assert_value "txete081u", evaluate("'u180etext'.reverse()")
+    assert_value "U+0062", evaluate("'2600+U'.reverse()")
+    assert_value "\ufeff\u2060\u200d\u200c\u200b\u180e", evaluate(%q('\u180e\u200b\u200c\u200d\u2060\ufeff'.reverse()))
+  end
+
+  private
+
+  def evaluate(expr, check: true)
+    env = Cel::Environment.new
+    env.extend_functions(Cel::Extra::Strings)
+    check ? env.evaluate(expr) : env.program(env.parse(expr)).evaluate
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -20,3 +20,18 @@ end
 require "tzinfo" # Required for timestamp timezone conversion tests
 
 require "cel"
+
+module CelAssertions
+  def assert_value(ruby_or_cel_value, cel_value)
+    if ruby_or_cel_value.is_a?(Cel::Value)
+      assert_equal(ruby_or_cel_value, cel_value)
+    else
+      assert_equal(ruby_or_cel_value, cel_value.to_ruby)
+    end
+  end
+
+  def assert_nil_value(cel_value)
+    assert_nil cel_value.to_ruby
+  end
+end
+Minitest::Test.include(CelAssertions)


### PR DESCRIPTION
String `format` isn’t quite conformant and two other conformance tests are failing [because they’re incorrect](https://github.com/google/cel-go/blob/master/conformance/BUILD.bazel#L52-L53), but this is otherwise a complete implementation of the string extension functions.